### PR TITLE
fix: upgrade @remix-run/testing package for module include errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@remix-run/testing": "^1.16.1",
+        "@remix-run/testing": "^1.19.3",
         "@storybook/addon-essentials": "^7.3.2",
         "@storybook/addon-interactions": "^7.3.2",
         "@storybook/addon-links": "^7.3.2",
@@ -4283,15 +4283,15 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.16.1.tgz",
-      "integrity": "sha512-Qp9B2htm0bGG0iuxsqezDIl89uVSBZ8xfwq2aKWgRNm1FCa4/GRXzKmTo+sbBcacj7aYe+1r+0sIS6Q1sgaEnA==",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.19.3.tgz",
+      "integrity": "sha512-z5qrVL65xLXIUpU4mkR4MKlMeKARLepgHAk4W5YY3IBXOreRqOGUC70POViYmY7x38c2Ia1NwqL80H+0h7jbMw==",
       "dev": true,
       "dependencies": {
-        "@remix-run/server-runtime": "1.16.1",
-        "@remix-run/web-fetch": "^4.3.4",
-        "@remix-run/web-file": "^3.0.2",
-        "@remix-run/web-stream": "^1.0.3",
+        "@remix-run/server-runtime": "1.19.3",
+        "@remix-run/web-fetch": "^4.3.6",
+        "@remix-run/web-file": "^3.0.3",
+        "@remix-run/web-stream": "^1.0.4",
         "@web3-storage/multipart-parser": "^1.0.0",
         "abort-controller": "^3.0.0",
         "cookie-signature": "^1.1.0",
@@ -4299,7 +4299,7 @@
         "stream-slice": "^0.1.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/node/node_modules/cookie-signature": {
@@ -4312,43 +4312,44 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.16.1.tgz",
-      "integrity": "sha512-vmqDXL/cHDIg3iKObtH+FltNwG+rviK1lCYgXSHgY17/95fve07hXRQalOr/ctt1jrGvGgaR4o/nlwlW7QMmpQ==",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.19.3.tgz",
+      "integrity": "sha512-iP37MZ+oG1n4kv4rX77pKT/knra51lNwKo5tinPPF0SuNJhF3+XjWo5nwEjvisKTXLZ/OHeicinhgX2JHHdDvA==",
       "dependencies": {
-        "@remix-run/router": "1.6.2",
-        "react-router-dom": "6.11.2"
+        "@remix-run/router": "1.7.2",
+        "react-router-dom": "6.14.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
-      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.16.1.tgz",
-      "integrity": "sha512-HG+f3PGE9kzTTPe5i5Hv7UGrJLmFID1Ae4BMohP5e0xXOxbdlKDPj6NN6yGDgE7OqKFuDVliW2B5LlUdJZgUFw==",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.19.3.tgz",
+      "integrity": "sha512-KzQ+htUsKqpBgKE2tWo7kIIGy3MyHP58Io/itUPvV+weDjApwr9tQr9PZDPA3yAY6rAzLax7BU0NMSYCXWFY5A==",
       "dev": true,
       "dependencies": {
-        "@remix-run/router": "1.6.2",
+        "@remix-run/router": "1.7.2",
+        "@types/cookie": "^0.4.1",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.4.1",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime/node_modules/cookie": {
@@ -4370,42 +4371,42 @@
       }
     },
     "node_modules/@remix-run/testing": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/testing/-/testing-1.16.1.tgz",
-      "integrity": "sha512-LjEsl/DC5G2wvWPkw2nACMFlvMBbRsw5QYJoy9JIrcaqUtAM9MF23cDoL+0XyVVaQ5dcBY7Q3FGJdgNLUoWltA==",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/testing/-/testing-1.19.3.tgz",
+      "integrity": "sha512-qO485TWDxHUnWuWX8PotBdq4xa5W3WUQ+iYvoWNCyILw6iJG0WeBTgd2qN44GFEOE1Hd80RqDXVuAlTkG33rCA==",
       "dev": true,
       "dependencies": {
-        "@remix-run/node": "1.16.1",
-        "@remix-run/react": "1.16.1",
-        "@remix-run/router": "1.6.2",
-        "react-router-dom": "6.11.2"
+        "@remix-run/node": "1.19.3",
+        "@remix-run/react": "1.19.3",
+        "@remix-run/router": "1.7.2",
+        "react-router-dom": "6.14.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@remix-run/web-blob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.4.tgz",
-      "integrity": "sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.5.tgz",
+      "integrity": "sha512-Mungj3erqCrq0+5zU/34NkeC2g+U7K6Uwa8uNiZgANvw0Wc64wKglk4MPQJZA0Y2tgPYXyrRn7uw4q75j6Hhww==",
       "dev": true,
       "dependencies": {
-        "@remix-run/web-stream": "^1.0.0",
+        "@remix-run/web-stream": "^1.0.4",
         "web-encoding": "1.1.5"
       }
     },
     "node_modules/@remix-run/web-fetch": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.4.tgz",
-      "integrity": "sha512-AUM1XBa4hcgeNt2CD86OlB5aDLlqdMl0uJ+89R8dPGx07I5BwMXnbopCaPAkvSBIoHeT/IoLWIuZrLi7RvXS+Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.7.tgz",
+      "integrity": "sha512-Ha6TuLiVHBbLuSNRgEQTz01pgG+bZVNogkKZt1cVi0asOuKISl0X2UgPLv+dWBqfcFvTi8CQvYUNuk5c89TcZw==",
       "dev": true,
       "dependencies": {
-        "@remix-run/web-blob": "^3.0.4",
-        "@remix-run/web-form-data": "^3.0.3",
-        "@remix-run/web-stream": "^1.0.3",
+        "@remix-run/web-blob": "^3.0.5",
+        "@remix-run/web-form-data": "^3.0.5",
+        "@remix-run/web-stream": "^1.0.4",
         "@web3-storage/multipart-parser": "^1.0.0",
         "abort-controller": "^3.0.0",
         "data-uri-to-buffer": "^3.0.1",
@@ -4416,27 +4417,27 @@
       }
     },
     "node_modules/@remix-run/web-file": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.0.2.tgz",
-      "integrity": "sha512-eFC93Onh/rZ5kUNpCQersmBtxedGpaXK2/gsUl49BYSGK/DvuPu3l06vmquEDdcPaEuXcsdGP0L7zrmUqrqo4A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.0.3.tgz",
+      "integrity": "sha512-yPf6MSXNcaQ4H1vkT/TSgImnqqfvfVKZzjd0vz3wvR0MM1NmrYfLbSbwfFLXdESFnQpXItbyKsgYGeAUEawgBg==",
       "dev": true,
       "dependencies": {
-        "@remix-run/web-blob": "^3.0.3"
+        "@remix-run/web-blob": "^3.0.5"
       }
     },
     "node_modules/@remix-run/web-form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.0.4.tgz",
-      "integrity": "sha512-UMF1jg9Vu9CLOf8iHBdY74Mm3PUvMW8G/XZRJE56SxKaOFWGSWlfxfG+/a3boAgHFLTkP7K4H1PxlRugy1iQtw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.0.5.tgz",
+      "integrity": "sha512-txXJDzjDuTxF8MFvEp9AA2HF3oPcvmlE1I/6HIxeGpX3vpBtrCPw5KQ/nzgBZNuAxyxEm8ps6Ds/UZwoDyfGsQ==",
       "dev": true,
       "dependencies": {
         "web-encoding": "1.1.5"
       }
     },
     "node_modules/@remix-run/web-stream": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.0.3.tgz",
-      "integrity": "sha512-wlezlJaA5NF6SsNMiwQnnAW6tnPzQ5I8qk0Y0pSohm0eHKa2FQ1QhEKLVVcDDu02TmkfHgnux0igNfeYhDOXiA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.0.4.tgz",
+      "integrity": "sha512-SVO42pH21I1sAhksGEM8ZBV/jc1mz6knZSg6Qo/2HPy9JTvtUykm3QMHtF2OMCTUXxdRW+4E/rphkPRyGc8WKw==",
       "dev": true,
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
@@ -6927,6 +6928,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
     },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.2",
@@ -13852,11 +13859,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
-      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
+      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
       "dependencies": {
-        "@remix-run/router": "1.6.2"
+        "@remix-run/router": "1.7.2"
       },
       "engines": {
         "node": ">=14"
@@ -13866,12 +13873,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
-      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
+      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
       "dependencies": {
-        "@remix-run/router": "1.6.2",
-        "react-router": "6.11.2"
+        "@remix-run/router": "1.7.2",
+        "react-router": "6.14.2"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/testing": "^1.16.1",
+    "@remix-run/testing": "^1.19.3",
     "@storybook/addon-essentials": "^7.3.2",
     "@storybook/addon-interactions": "^7.3.2",
     "@storybook/addon-links": "^7.3.2",


### PR DESCRIPTION
## Purpose:
- hotfix for upgrade @remix-run/testing package for module include errors

### Ticket(s)
[CSU-XX](https://fourkitchens.clickup.com/t/36718269/CSU-XX)

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [ ] Run `npm run dev` and verify you have no module include errors on the colors component (and others too but the colors component definitely consistently had the error)
