### PR TITLE
CSU-103: Add experience-form-list component / update experience-page component

### DIFF
--- a/src/components/02-components/experience-form-list/experience-form-list.stories.tsx
+++ b/src/components/02-components/experience-form-list/experience-form-list.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ExperienceFormList from './experience-form-list';
+
+const meta: Meta<typeof ExperienceFormList> = {
+  title: 'Components/Experience Form List',
+  component: ExperienceFormList,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof ExperienceFormList> = {
+  args: {
+    beginningForms: [
+      {
+        id: 'form-1',
+        name: 'Release of Liability - COVID 19',
+        status: 'Submitted',
+      },
+    ],
+    duringForms: [
+      {
+        id: 'form-2',
+        name: 'Proident mollit nisi id esse eiusmod cillum eiusmod',
+        status: 'Submitted',
+      },
+      {
+        id: 'form-3',
+        name: 'Id officia ut commodo ipsum non adipisicing voluptate',
+        status: 'Pending',
+      },
+      {
+        id: 'form-4',
+        name: 'Voluptate magna sunt aliqua cillum',
+        status: 'Pending',
+      },
+    ],
+    endForms: [
+      {
+        id: 'form-5',
+        name: 'Reprehenderit cillum reprehenderit est magna veniam non ea duis quis veniam id cillum',
+        status: 'Pending',
+      },
+      {
+        id: 'form-6',
+        name: 'Minim aliqua ut sunt eu velit cillum dolor et',
+        status: 'Pending',
+      },
+    ],
+  },
+};

--- a/src/components/02-components/experience-form-list/experience-form-list.tsx
+++ b/src/components/02-components/experience-form-list/experience-form-list.tsx
@@ -1,0 +1,145 @@
+import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { Box, Button, Link, Paper, Typography, useTheme } from '@mui/material';
+
+type FormProps = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+type ExperienceFormListProps = {
+  beginningForms: FormProps[] | undefined;
+  duringForms: FormProps[] | undefined;
+  endForms: FormProps[] | undefined;
+  formBaseUrl?: string;
+};
+
+export default function ExperienceFormList({
+  beginningForms,
+  duringForms,
+  endForms,
+  formBaseUrl = '/forms/',
+}: ExperienceFormListProps) {
+  const theme = useTheme();
+
+  const formWrapperStyle = {
+    py: theme.spacing(2),
+    px: theme.spacing(4),
+    mb: theme.spacing(5),
+  };
+
+  const headingFormStyles = {
+    mb: theme.spacing(3),
+  };
+
+  const formListStyles = {
+    m: `${theme.spacing(3)} 0 0`,
+    p: 0,
+    listStyleType: 'none',
+  };
+
+  const formItemStyles = {
+    py: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.secondary.light}`,
+    borderBottom: `1px solid ${theme.palette.secondary.light}`,
+    [theme.breakpoints.up('sm')]: {
+      display: 'flex',
+    },
+  };
+
+  const formItemNameStyles = {
+    mb: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      flexBasis: '50%',
+      pr: theme.spacing(2),
+      mb: 0,
+    },
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '30%',
+    },
+  };
+
+  const formItemStatusStyles = {
+    display: 'flex',
+    mb: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      flexBasis: '20%',
+      mb: 0,
+    },
+  };
+
+  const iconSubmittedStyles = {
+    color: theme.palette.success.main,
+    marginRight: theme.spacing(1),
+  };
+
+  const iconPendingStyles = {
+    color: theme.palette.warning.main,
+    marginRight: theme.spacing(1),
+  };
+
+  function ListSection({ items }: { items: FormProps[] }) {
+    return (
+      <Box component="ul" sx={formListStyles}>
+        {items.map((item) => (
+          <Box component="li" key={item.id} sx={formItemStyles}>
+            <Typography sx={formItemNameStyles}>{item.name}</Typography>
+            <Typography variant="body2" sx={formItemStatusStyles}>
+              {item.status === 'Submitted' ? (
+                <CheckCircleOutlineOutlinedIcon sx={iconSubmittedStyles} />
+              ) : (
+                <ErrorOutlineIcon sx={iconPendingStyles} />
+              )}
+              {item.status}
+            </Typography>
+            <Button
+              variant="outlined"
+              component={Link}
+              href={`${formBaseUrl}${item.id}`}
+              sx={{ flexShrink: 0 }}
+            >
+              Complete form
+            </Button>
+          </Box>
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <Paper sx={formWrapperStyle}>
+      <Typography sx={headingFormStyles} variant="h2">
+        Forms
+      </Typography>
+      {beginningForms && (
+        <>
+          {beginningForms && (
+            <Box>
+              <Typography mt={3} variant="h4" component="h3">
+                Beginning of Term
+              </Typography>
+              <ListSection items={beginningForms} />
+            </Box>
+          )}
+          {duringForms && (
+            <Box>
+              <Typography mt={3} variant="h4" component="h3">
+                During Term
+              </Typography>
+              <ListSection items={duringForms} />
+            </Box>
+          )}
+          {endForms && (
+            <Box>
+              <Typography mt={3} variant="h4" component="h3">
+                End of Term
+              </Typography>
+              <ListSection items={endForms} />
+            </Box>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/src/components/02-components/experience-page/experience-page.stories.tsx
+++ b/src/components/02-components/experience-page/experience-page.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import { Default as ExperienceFormListStory } from '../experience-form-list/experience-form-list.stories';
 import TimeLogTable, {
   type TimeLogTableProps,
 } from '../time-log-table/time-log-table';
@@ -40,38 +41,7 @@ export const Student: StoryObj<typeof ExperiencePage> = {
     timeApprover: 'Name Lastname, Name Lastname',
     observer: 'Name Lastname',
     hasPendingForm: true,
-    formsBegining: {
-      items: [
-        {
-          id: '1',
-          formName: 'Release of Liability - COVID 19',
-          statusFoms: 'Submitted',
-          urlForm: '/opportunities',
-        },
-        {
-          id: '2',
-          formName: 'Release of Liability - COVID 19',
-          statusFoms: 'Pending',
-          urlForm: '/opportunities',
-        },
-      ],
-    },
-    formsDuring: {
-      items: [
-        {
-          id: '1',
-          formName: 'Release of Liability - COVID 19',
-          statusFoms: 'Submitted',
-          urlForm: '/opportunities',
-        },
-        {
-          id: '2',
-          formName: 'Release of Liability - COVID 19',
-          statusFoms: 'Pending',
-          urlForm: '/opportunities',
-        },
-      ],
-    },
+    ...ExperienceFormListStory.args,
   },
   render: (args) => (
     <ExperiencePage {...args}>

--- a/src/components/02-components/experience-page/experience-page.tsx
+++ b/src/components/02-components/experience-page/experience-page.tsx
@@ -1,18 +1,16 @@
-import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import {
-  Box,
-  Button,
-  Divider,
-  Paper,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import { Box, Divider, Paper, Typography, useTheme } from '@mui/material';
 import { ReactNode } from 'react';
 import { experienceStatusInfo } from '../../../lib/utils';
 import Breadcrumbs from '../../01-elements/breadcrumbs/breadcrumbs';
-import Link from '../../01-elements/link/link';
 import CardExperienceHours from '../card-experience-hours/card-experience-hours';
+import ExperienceFormList from '../experience-form-list/experience-form-list';
+
+type FormProps = {
+  id: string;
+  name: string;
+  status: string;
+};
 
 export type ExperiencePageProps = {
   children?: ReactNode;
@@ -35,22 +33,10 @@ export type ExperiencePageProps = {
   timeApprover: string;
   observer: string;
   hasPendingForm: boolean;
-  formsBegining?: {
-    items: {
-      id: string;
-      formName: string;
-      statusFoms: string;
-      urlForm: string;
-    }[];
-  };
-  formsDuring?: {
-    items: {
-      id: string;
-      formName: string;
-      statusFoms: string;
-      urlForm: string;
-    }[];
-  };
+  beginningForms?: FormProps[];
+  duringForms?: FormProps[];
+  endForms?: FormProps[];
+  formBaseUrl?: string;
 };
 
 export default function ExperiencePage({
@@ -68,13 +54,15 @@ export default function ExperiencePage({
   location,
   hours,
   hoursCtaUrl,
-  formsBegining,
-  formsDuring,
+  beginningForms,
+  duringForms,
+  endForms,
   primaryContact,
   formSigner,
   timeApprover,
   observer,
   hasPendingForm,
+  formBaseUrl,
 }: ExperiencePageProps) {
   const theme = useTheme();
 
@@ -88,48 +76,6 @@ export default function ExperiencePage({
 
   const headingStyles = {
     fontWeight: '700',
-  };
-
-  const headingFormItemStyles = {
-    fontWeight: '700',
-    marginTop: theme.spacing(3),
-  };
-
-  const headingFormStyles = {
-    mb: theme.spacing(3),
-  };
-
-  const formWrapperStyle = {
-    p: `${theme.spacing(2)} ${theme.spacing(4)} `,
-    mb: theme.spacing(5),
-  };
-
-  const formListStyles = {
-    m: `${theme.spacing(3)} 0 0`,
-    p: 0,
-    listStyleType: 'none',
-  };
-
-  const formItemStyles = {
-    display: 'flex',
-    py: theme.spacing(2),
-    alignItems: 'center',
-    flexDirection: 'column',
-    borderTop: `1px solid ${theme.palette.secondary.light}`,
-    borderBottom: `1px solid ${theme.palette.secondary.light}`,
-    [theme.breakpoints.up('md')]: {
-      alignItems: 'flex-start',
-      flexDirection: 'row',
-    },
-  };
-
-  const formItemNameStyles = {
-    flexBasis: '30%',
-  };
-
-  const formItemStatusStyles = {
-    display: 'flex',
-    flexBasis: '20%',
   };
 
   const descriptionStyles = {
@@ -208,11 +154,6 @@ export default function ExperiencePage({
 
   const cardHoursStyles = {
     flex: '1 0 25%',
-  };
-
-  const iconSubmittedStyles = {
-    color: theme.palette.success.main,
-    marginRight: theme.spacing(1),
   };
 
   const iconPendingStyles = {
@@ -362,80 +303,13 @@ export default function ExperiencePage({
           </Box>
         </Paper>
 
-        {formsBegining || formsDuring ? (
-          <Paper sx={formWrapperStyle}>
-            <Typography sx={headingFormStyles} variant="h2">
-              Forms
-            </Typography>
-            {formsBegining && (
-              <Box>
-                <Typography sx={headingFormItemStyles} variant="h4">
-                  Beginning of Term
-                </Typography>
-                <Box component="ul" sx={formListStyles}>
-                  {formsBegining.items.map((item) => (
-                    <Box component="li" key={item.id} sx={formItemStyles}>
-                      <Typography sx={formItemNameStyles}>
-                        {item.formName}
-                      </Typography>
-                      <Typography variant="body2" sx={formItemStatusStyles}>
-                        {item.statusFoms === 'Submitted' ? (
-                          <CheckCircleOutlineOutlinedIcon
-                            sx={iconSubmittedStyles}
-                          />
-                        ) : (
-                          <ErrorOutlineIcon sx={iconPendingStyles} />
-                        )}
-                        {item.statusFoms}
-                      </Typography>
-                      <Button
-                        variant="outlined"
-                        component={Link}
-                        href={item.urlForm}
-                        sx={{ flexShrink: 0 }}
-                      >
-                        Complete form
-                      </Button>
-                    </Box>
-                  ))}
-                </Box>
-              </Box>
-            )}
-            {formsDuring && (
-              <Box>
-                <Typography sx={headingFormItemStyles} variant="h4">
-                  During Term
-                </Typography>
-                <Box component="ul" sx={formListStyles}>
-                  {formsDuring.items.map((item) => (
-                    <Box component="li" key={item.id} sx={formItemStyles}>
-                      <Typography sx={formItemNameStyles}>
-                        {item.formName}
-                      </Typography>
-                      <Typography variant="body2" sx={formItemStatusStyles}>
-                        {item.statusFoms === 'Submitted' ? (
-                          <CheckCircleOutlineOutlinedIcon
-                            sx={iconSubmittedStyles}
-                          />
-                        ) : (
-                          <ErrorOutlineIcon sx={iconPendingStyles} />
-                        )}
-                        {item.statusFoms}
-                      </Typography>
-                      <Button
-                        variant="outlined"
-                        component={Link}
-                        href={item.urlForm}
-                        sx={{ flexShrink: 0 }}
-                      >
-                        Complete form
-                      </Button>
-                    </Box>
-                  ))}
-                </Box>
-              </Box>
-            )}
-          </Paper>
+        {beginningForms || duringForms || endForms ? (
+          <ExperienceFormList
+            beginningForms={beginningForms}
+            duringForms={duringForms}
+            endForms={endForms}
+            formBaseUrl={formBaseUrl}
+          />
         ) : null}
         {children}
       </Box>


### PR DESCRIPTION
## Purpose:
- Improvements and fixes to the experience page component
- Create a separate component for handling the list of forms in the experience page

### Ticket(s)
[CSU-103](https://fourkitchens.clickup.com/t/36718269/CSU-103)

### Functional Testing:
- [ ] Visit the [Experience Form List](http://localhost:6006/?path=/story/components-experience-form-list--default) and [Experience Page](http://localhost:6006/?path=/story/components-experience-page--student) components in Storybook. Check that they look and work as expected.
