### PR TITLE
CSU-347: Faculty can view course details block on the course details

### DIFF
--- a/src/components/04-pages/faculty/courses/course-details/course-details.stories.tsx
+++ b/src/components/04-pages/faculty/courses/course-details/course-details.stories.tsx
@@ -33,6 +33,12 @@ const courseDetailsArgs: CourseDetailsPageProps = {
     },
   ],
   title: 'Course Title',
+  term: 'Spring 2022',
+  program: 'Service Learning',
+  experience: 'Required',
+  max: '1',
+  lmsLink: '#lms-link',
+  faculty: 'Jordan, Rachel',
   tableData: {
     rows: enrolledStudentsTableRows,
     columns: enrolledStudentsTableColumns,

--- a/src/components/04-pages/faculty/courses/course-details/course-details.tsx
+++ b/src/components/04-pages/faculty/courses/course-details/course-details.tsx
@@ -1,10 +1,11 @@
-import { Paper, Box, Typography, useTheme } from '@mui/material';
+import {Paper, Box, Typography, useTheme, Button} from '@mui/material';
 import DataTable, {
   DataTableProps,
 } from '../../../../02-components/data-table/data-table';
 import { useRef } from "react";
 import Tabs, { type RefHandler } from '../../../../02-components/tabs/tabs';
 import Breadcrumbs from '../../../../01-elements/breadcrumbs/breadcrumbs';
+import Link from "~/components/01-elements/link/link";
 
 export type CourseDetailsPageProps = {
   breadcrumb: {
@@ -12,6 +13,12 @@ export type CourseDetailsPageProps = {
     url: string;
   }[];
   title: string;
+  term: string;
+  program: string;
+  experience: string;
+  max: string;
+  lmsLink: string;
+  faculty: string;
   tableData: DataTableProps;
   reportTableData: DataTableProps;
 };
@@ -19,6 +26,12 @@ export type CourseDetailsPageProps = {
 export default function CourseDetailsPage({
     breadcrumb,
     title,
+    term,
+    program,
+    experience,
+    max,
+    lmsLink,
+    faculty,
     tableData,
     reportTableData,
   }: CourseDetailsPageProps) {
@@ -50,6 +63,59 @@ export default function CourseDetailsPage({
     }
   };
 
+  const blockContainerStyles = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'flex-start',
+    pt: theme.spacing(3),
+    pb: theme.spacing(3),
+    mb: theme.spacing(4),
+  };
+
+  const titleBlock = {
+    mb: theme.spacing(2),
+  };
+
+  const itemCol = {
+    flexGrow: 1,
+    pl: theme.spacing(3),
+    pr: theme.spacing(3),
+    pb: theme.spacing(1),
+    [theme.breakpoints.down('md')]: {
+      pb: theme.spacing(3),
+    },
+    [theme.breakpoints.down('sm')]: {
+      pb: theme.spacing(3),
+    }
+  };
+
+  const leftLine = {
+    borderLeft: '1px solid rgba(224, 224, 224, 1)',
+    [theme.breakpoints.down('md')]: {
+      borderLeft: '0',
+    },
+  };
+
+  const spaceTop = {
+    pt: theme.spacing(4),
+  };
+
+  const definitionListStyles = {
+    mt: 0,
+    mb: theme.spacing(1),
+    dt: {
+      display: 'inline',
+      fontWeight: '700',
+    },
+    dd: {
+      display: 'inline',
+      ml: 0,
+    },
+    [theme.breakpoints.up('sm')]: {
+      mb: 0,
+    },
+  };
+
   return (
     <>
       <Breadcrumbs items={breadcrumb} />
@@ -58,6 +124,59 @@ export default function CourseDetailsPage({
           {title}
         </Typography>
       </Box>
+      <Paper sx={blockContainerStyles}>
+        <Box sx={itemCol}>
+          <Typography variant="h4" sx={titleBlock}>Course Detail</Typography>
+          {term && (
+            <Box sx={definitionListStyles} component="dl">
+              <dt>Term: </dt>
+              <dd>{term}</dd>
+            </Box>
+          )}
+          {program && (
+            <Box sx={definitionListStyles} component="dl">
+              <dt>Program: </dt>
+              <dd>{program}</dd>
+            </Box>
+          )}
+        </Box>
+        <Box sx={[itemCol, spaceTop]}>
+          {experience && (
+            <Box sx={definitionListStyles} component="dl">
+              <dt>Experience Requirement: </dt>
+              <dd>{experience}</dd>
+            </Box>
+          )}
+          {max && (
+            <Box sx={definitionListStyles} component="dl">
+              <dt>Max placements per student: </dt>
+              <dd>{max}</dd>
+            </Box>
+          )}
+        </Box>
+        <Box sx={[itemCol, leftLine]}>
+          {lmsLink && (
+            <>
+              <Typography variant="h4" sx={titleBlock}>Syllabus</Typography>
+              <Button
+                variant="outlined"
+                color="inherit"
+                href={lmsLink}
+              >
+                VISIT (LMS LINK)
+              </Button>
+            </>
+          )}
+        </Box>
+        <Box sx={[itemCol, leftLine]}>
+          {faculty && (
+            <>
+              <Typography variant="h4" sx={titleBlock}>Faculty</Typography>
+              <Box>{faculty}</Box>
+            </>
+          )}
+        </Box>
+      </Paper>
       <Box sx={wrapperTabs}>
         <Tabs
           name="Course Details tables"


### PR DESCRIPTION
## Purpose:
- Faculty can view the course details block on the course details page.

### Ticket(s)
[CSU-347](https://fourkitchens.clickup.com/t/36718269/CSU-347)

### Pull Request Deployment:
- Normal deployment process (`npm run rebuild` on local and ci on github)

### Functional Testing:
- [ ] Go to any group detail page and there you should see a block on the top of the page displaying the data related to the course (Term, Program, Experience Requirement, Max placements, Syllabus, Faculty). http://localhost:6006/iframe.html?viewMode=story&id=pages-faculty-courses-course-details--enrolled-students-table&args=#lms-link
### Notes:
_Additional notes_
